### PR TITLE
Adds a post about Architecture Decision Records

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Contributions are welcome! Check out the contribution guidelines for adding item
 - [🗺🧭 Using Wardley Mapping to understand why Google made G. Appointments to compete in the Calendly market by Aleix Morgadas](https://learnings.aleixmorgadas.dev/p/-using-wardley-mapping-to-understand) - Using wardley mapping to understand google appointments.
 - [What is a Strategy? Why do you need one in Tech?](https://www.linkedin.com/pulse/what-strategy-why-do-you-need-one-tech-rui-felgueiras) - Introduction to what is a strategy for tech.
 - [Delivering on an Architecture Strategy](https://blog.thepete.net/blog/2019/12/09/delivering-on-an-architecture-strategy/) - Describes strategic architectural initiatives, a framework which allowing product peeps and techies to make progress on big technical improvements via aligned autonomy.
+- [ADR: Deep Dive into Architecture Decision Records](https://okorkmaz.medium.com/adr-deep-dive-into-architecture-decision-records-8c110ce7d74e) - Introduces what an architecture decision record is, describes the terminology, how to document the finalized architecture, and focuses on the best practices by presenting real scenerio.
 
 
 ## Templates


### PR DESCRIPTION
This is a medium post that illustrates the architecture decision records and the use-case scenarios explaining the terminology and documentation path of the architecture you decided on as a team. This documentation is helpful for medium and large-scale teams to refer to the architectures already decided and documented depending on the motivations. This post may help all engineers work in any domain while iterating architectural problems.